### PR TITLE
Calculate gas price based on RSKIP-09

### DIFF
--- a/rsk-faucet.js
+++ b/rsk-faucet.js
@@ -114,7 +114,8 @@ var web3;
 getWeb3();
 
 function executeTransfer(destinationAddress) {
-  var rawTx = buildTx(destinationAddress, getNonce(), getGasPrice());
+  var gasPrice = estimateGasPrice();
+  var rawTx = buildTx(destinationAddress, getNonce(), gasPrice);
   var result = web3.eth.sendRawTransaction(rawTx.toString('hex'), function(err, hash){
     if (!err)
       console.log('transaction hash', hash);
@@ -141,12 +142,12 @@ function getNonce(){
   return result;
 }
 
-function getGasPrice(){
+function estimateGasPrice(){
   var block = web3.eth.getBlock("latest")
   if (block.minimumGasPrice <= 1) {
     return 1;
   } else {
-    return block.minimumGasPrice;
+    return block.minimumGasPrice * 1.0001;
   }
 }
 


### PR DESCRIPTION
Based on RSKIP-09 the minimum gas price can variate on 0.01%. To ensure the transaction can be mined, that 0.01% should be added to the gas price.